### PR TITLE
Add status-page component implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "swr": "2.2.5"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.1",
@@ -11123,6 +11124,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/table": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
@@ -11518,6 +11531,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "swr": "2.2.5"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.1",

--- a/pages/status/index.js
+++ b/pages/status/index.js
@@ -1,0 +1,44 @@
+import useSWR from "swr";
+
+async function fetchAPI(key) {
+  const response = await fetch(key);
+  const responseBody = await response.json();
+
+  return responseBody;
+}
+
+export default function StatusPage() {
+  return (
+    <>
+      <h1>Status</h1>
+      <UpdatedAt />
+    </>
+  );
+}
+
+function UpdatedAt() {
+  const { isLoading, data } = useSWR("/api/v1/status", fetchAPI, {
+    refreshInterval: 2000,
+  });
+
+  let updatedAtText = "Carregando...";
+  let databaseInfo = {};
+
+  if (!isLoading && data) {
+    databaseInfo = data.dependencies.database;
+    updatedAtText = new Date(data.updated_at).toLocaleString("pt-BR");
+  }
+
+  return (
+    <div>
+      última atualização: {updatedAtText}
+      <br />
+      <br />
+      Versão do banco de dados: {databaseInfo.version || "Carregando..."}
+      <br />
+      Conexões ativas: {databaseInfo.opened_connections || "Carregando..."}
+      <br />
+      Máximo de conexões: {databaseInfo.max_connections || "Carregando..."}
+    </div>
+  );
+}


### PR DESCRIPTION
### Context

This component will fetch to `/api/v1/status` to get the health-check data and preset to the use
data like: the last time data was retrieved and some database information

fix https://github.com/BatistaGabriel/clone-tabnews/issues/26

### Demo

Here's a demo on how the component reacts on the page

![firefox_or71yQqmum](https://github.com/user-attachments/assets/de1dfe63-bef2-4201-a7a0-8373ffba6e9e)

